### PR TITLE
Documentation: Correct SCSS Syntax

### DIFF
--- a/pages/docs/introduction/customization.md
+++ b/pages/docs/introduction/customization.md
@@ -25,11 +25,11 @@ Vue.use(Inkline);
 
 ### Variables
 
-Create a new Sass file called `variables.scss`, where we'll define the values you want to use with Inkline. Let's say we want to override the primary and secondary colors for all components.
+Create a new Sass file called `_variables.scss`, where we'll define the values you want to use with Inkline. Let's say we want to override the primary and secondary colors for all components.
 
 ~~~scss 
-$color-primary := #d84550
-$color-secondary := #f49b4e
+$color-primary: #D84550;
+$color-secondary: #F49B4E;
 ~~~
 
 ### Configuration


### PR DESCRIPTION
`:=` is not valid Sass syntax.

You can paste the following into https://SassMeister.com to see:

```sass
$cow: #F00 !default

$cow := #00F

.cow
    background: $cow
```

Also the instructions say to create `variables.scss` however the existing code example is lacking `;` which implies `.sass` syntax. If you are intentionally leaving out the `;` then you should change the instructions to say "Create a Sass file called `_variables.sass`". Either way, you should begin the file with an `_` to infer it is a partial and should not be processed to output a mirror CSS file (`variables.css`).